### PR TITLE
Added stepper dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "author": "Donovan Buck <donovan@donovan.bz>",
   "license": "MIT",
   "dependencies": {
+    "async": "^1.5.0",
     "hapi": "^8.8.1",
     "johnny-five": "^0.8.81",
     "keypress": "^0.2.1",
-    "socket.io": "^1.3.6"
+    "socket.io": "^1.3.6",
+    "trier": "philbooth/trier.js"
   }
 }


### PR DESCRIPTION
The GitHub reference is used for trier since the npm version is not correctly installing (at least for me.)
